### PR TITLE
fix: set $combat visibility to hidden when mouseleave

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -377,6 +377,7 @@ import boxers from "../boxers.json"
 
         $combat.style.opacity = "0";
         $combat.style.transition = "all .3s ease-in-out";
+        $combat.style.visibility = "hidden";
       });
 
       $img.addEventListener("mouseenter", () => {


### PR DESCRIPTION
Luego de hacer mouseenter en un combatiente se le ponia un visibility: visible a la caja del VS, pero al hacer un mouseleave no se le ponia un visibility; hidden, solo agregue eso para mejorar la UX :)